### PR TITLE
update HBase repository location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update
 RUN apt-get install -y build-essential curl openjdk-6-jdk
 
 # Download and Install HBase
-ENV HBASE_VERSION 0.94.25
+ENV HBASE_VERSION 0.94.26
 
-RUN mkdir -p /opt/downloads && cd /opt/downloads && curl -SsfLO "https://dl.dropboxusercontent.com/u/91148410/SharedFiles/hbase-0.94.25.tar.gz"
+RUN mkdir -p /opt/downloads && cd /opt/downloads && curl -SsfLO "http://archive.apache.org/dist/hbase/hbase-$HBASE_VERSION/hbase-$HBASE_VERSION.tar.gz"
 RUN cd /opt && tar xvfz /opt/downloads/hbase-$HBASE_VERSION.tar.gz
 RUN mv /opt/hbase-$HBASE_VERSION /opt/hbase
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update
 RUN apt-get install -y build-essential curl openjdk-6-jdk
 
 # Download and Install HBase
-ENV HBASE_VERSION 0.94.26
+ENV HBASE_VERSION 0.94.25
 
-RUN mkdir -p /opt/downloads && cd /opt/downloads && curl -SsfLO "http://www.apache.org/dist/hbase/hbase-$HBASE_VERSION/hbase-$HBASE_VERSION.tar.gz"
+RUN mkdir -p /opt/downloads && cd /opt/downloads && curl -SsfLO "https://dl.dropboxusercontent.com/u/91148410/SharedFiles/hbase-0.94.25.tar.gz"
 RUN cd /opt && tar xvfz /opt/downloads/hbase-$HBASE_VERSION.tar.gz
 RUN mv /opt/hbase-$HBASE_VERSION /opt/hbase
 


### PR DESCRIPTION
Official 0.94.xx is no longer supported or missing. It's not available anymore in the repository. Here I have backup for it from my Dropbox but version 0.94.25 built against Hadoop 2.4.1 (I use for replicate Amazon AWS default Elastic MapReduce package). It can be merged with no error or if you want just download it and move it repository that you have.