### PR TITLE
Added support for custom hostnames

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ADD ./hbase-site.xml /opt/hbase/conf/hbase-site.xml
 
 ADD ./zoo.cfg /opt/hbase/conf/zoo.cfg
 
+ADD ./replace-hostname /opt/replace-hostname
+
 ADD ./hbase-server /opt/hbase-server
 
 # REST API

--- a/config-hbase.sh
+++ b/config-hbase.sh
@@ -3,7 +3,7 @@
 # . /build/config.sh
 
 HBASE_DIST="http://apache.cs.utah.edu/hbase"
-#HBASE_DIST="http://archive.apache.org/dist/hbase"
+HBASE_DIST="http://archive.apache.org/dist/hbase"
 
 # Prevent initramfs updates from trying to run grub and lilo.
 export INITRD=no

--- a/hbase-server
+++ b/hbase-server
@@ -5,6 +5,8 @@
 
 logs_dir=/data/logs
 
+# Prepare environment
+/opt/replace-hostname
 mkdir -p $logs_dir /data/hbase /data/run
 
 # Thrift server (background)

--- a/replace-hostname
+++ b/replace-hostname
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Script that replaces the default hostname in files with the environments
+# ${HOSTNAME} variable.
+#
+# This script is intended to be run before starting hbase-server to ensure
+# that the hostname matches the configured environment variable. i.e.
+# the -h --hostname flag.
+#
+declare -a files=(
+	'/opt/hbase/conf/hbase-site.xml'
+	'/opt/hbase/conf/zoo.cfg'
+)
+
+for file in "${files[@]}"; do
+	if [ -f "${file}.bak" ]; then
+		cp "${file}.bak" "${file}"
+	else
+		cp "${file}" "${file}.bak"
+	fi
+
+	sed -i "s/hbase-docker/${HOSTNAME}/g" "${file}"
+done


### PR DESCRIPTION
Right now, the image requires that the docker contains be named hbase-docker. This limits machines to running a single hbase instance per machine.

With this patch it will use the HOSTNAME environment variable set by the docker-run `-h --hostname` argument.