### PR TITLE
Exit immediately if there is any error in a shell script

### DIFF
--- a/build-hbase.sh
+++ b/build-hbase.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh -xe
 
 . /build/config-hbase.sh
 

--- a/cleanup-hbase.sh
+++ b/cleanup-hbase.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh -xe
 
 . /build/config-hbase.sh
 

--- a/prepare-hbase.sh
+++ b/prepare-hbase.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh -xe
 
 . /build/config-hbase.sh
 

--- a/start-hbase.sh
+++ b/start-hbase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Script to start docker and update the /etc/hosts file to point to
 # the hbase-docker container


### PR DESCRIPTION
Exit immediately if there is any error in a shell script. This changes this error message:

```
$ ./start-hbase.sh 
Starting HBase container
docker: Error response from daemon: Conflict. The name "/hbase-docker" is already in use by container 19cac72a53ebb95ae5e6a41b4fcd0b5e7455363cab526255f7b716a75474f96d. You have to remove (or rename) that container to be able to reuse that name..
See 'docker run --help'.
Container has ID 
docker: "inspect" requires a minimum of 1 argument.
See 'docker inspect --help'.

Usage:	docker inspect [OPTIONS] CONTAINER|IMAGE|TASK [CONTAINER|IMAGE|TASK...]

Return low-level information on a container, image or task
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python2.7/json/__init__.py", line 291, in load
    **kw)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python2.7/json/__init__.py", line 291, in load
    **kw)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
Updating /etc/hosts to make hbase-docker point to  ()
Now connect to hbase at localhost on the standard ports
  ZK 2181, Thrift 9090, Master 16000, Region 16020
Or connect to host hbase-docker (in the container) on the same ports

For docker status:
$ id=
$ docker inspect $id

```
into something much more readable:
```
./start-hbase.sh 
Starting HBase container
docker: Error response from daemon: Conflict. The name "/hbase-docker" is already in use by container 19cac72a53ebb95ae5e6a41b4fcd0b5e7455363cab526255f7b716a75474f96d. You have to remove (or rename) that container to be able to reuse that name..
See 'docker run --help'.
```